### PR TITLE
refactor: change the CIN validator

### DIFF
--- a/src/validators/cin.test.ts
+++ b/src/validators/cin.test.ts
@@ -5,7 +5,6 @@ describe("CIN Validator", () => {
     it("should validate correct CIN numbers", () => {
       expect(validateCIN("12345678")).toBe(true);
       expect(validateCIN("00123456")).toBe(true);
-      expect(validateCIN("99999999")).toBe(true);
     });
 
     it("should reject CINs with invalid length", () => {
@@ -18,6 +17,7 @@ describe("CIN Validator", () => {
       expect(validateCIN("ABCDEFGH")).toBe(false);
       expect(validateCIN("1234-678")).toBe(false);
       expect(validateCIN("1234|#•@")).toBe(false);
+      expect(validateCIN("99999999")).toBe(false);
     });
 
     it("should reject empty strings and null values", () => {

--- a/src/validators/cin.ts
+++ b/src/validators/cin.ts
@@ -1,7 +1,7 @@
 /**
  * Regular expression for CIN validation
  */
-const CIN_REGEX = /^\d{8}$/;
+const CIN_REGEX = /^[01]\d{7}$/; // 0 or 1 followed by 7 digits to match the tunisian CIN format
 
 /**
  * Validates a Tunisian CIN (Carte d'Identité Nationale)


### PR DESCRIPTION
This pull request updates the CIN (Carte d'Identité Nationale) validation logic to align with the Tunisian format and adjusts the corresponding test cases. The most important changes include modifying the validation regex and updating the test cases to reflect the new validation rules.

### Validation logic update:
* [`src/validators/cin.ts`](diffhunk://#diff-c12373f9389658587f8ded60a7545fee33f26bab88acc5208395a3e13192d644L4-R4): Updated the `CIN_REGEX` to ensure that valid CINs start with `0` or `1` followed by 7 digits, reflecting the Tunisian format.

### Test case adjustments:
* [`src/validators/cin.test.ts`](diffhunk://#diff-d384295c36a4abb06e8b01d5c2d5cccd7627a54518b654c398585735f7b69819L8): Removed `99999999` from the list of valid CINs in the test case for correct CIN validation.
* [`src/validators/cin.test.ts`](diffhunk://#diff-d384295c36a4abb06e8b01d5c2d5cccd7627a54518b654c398585735f7b69819R20): Added `99999999` to the list of invalid CINs in the test case for rejecting invalid CINs.